### PR TITLE
fill in placeholder from gem generator in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/tty-pie_chart. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/piotrmurach/tty-pie_chart. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 


### PR DESCRIPTION
### Describe the change
What does this Pull Request do?

Fixes a placeholder in the readme :)

### Why are we doing this?
Any related context as to why is this is a desirable change.

The URL in the Readme is incorrect

### Benefits
How will the library improve?

By not having a broken link in the Readme

### Drawbacks
Possible drawbacks applying this change.

People won't be able to see GitHub's lovely 404 page

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
[] Code style checked?
[] Rebased with `master` branch?
[] Documentaion updated?
